### PR TITLE
Kl/upgrade/remove saving temp fits file to disk

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,10 @@ on the ESO SkyCalc server. For references to SkyCalc see `ESO SkyCalc`_,
     - `wgrid_mode`: --> `fixed_spectral_resolution`
     - `wres`: --> `1000  wave/dwave`
 
+.. note:: v0.1.3: No longer saves a temporary FITS file to disk.
+
+    SkyCalc now uses astropy to download the fits file from the SkyCalc server.
+    The HDUList is now stored internally in `<SkyCalc>.last_skycalc_response`.
 
 .. note:: v0.1.2: Upgrade fixes PyYaml warning/error for PyYaml >=6.0
 

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -11,6 +11,8 @@ import json
 from datetime import datetime
 import requests
 
+from astropy.io import fits
+
 
 class AlmanacQuery:
     """
@@ -341,19 +343,34 @@ class SkyModel:
 
     def retrieve_data(self, url):
         try:
-            response = requests.get(url, stream=True)
-            self.data = response.content
+            self.data = fits.open(url)
         except requests.exceptions.RequestException as e:
             self.handle_exception(
                 e, 'Exception raised trying to get FITS data from ' + url)
 
-    def write(self, local_filename):
+    def write(self, local_filename, **kwargs):
         try:
-            with open(local_filename, 'wb') as f:
-                f.write(self.data)
+            self.data.writeto(local_filename, **kwargs)
         except IOError as e:
             self.handle_exception(
                 e, 'Exception raised trying to write fits file ')
+
+    # ORIGINAL CODE
+    # def retrieve_data(self, url):
+    #     try:
+    #         response = requests.get(url, stream=True)
+    #         self.data = response.content
+    #     except requests.exceptions.RequestException as e:
+    #         self.handle_exception(
+    #             e, 'Exception raised trying to get FITS data from ' + url)
+
+    # def write(self, local_filename):
+    #     try:
+    #         with open(local_filename, 'wb') as f:
+    #             f.write(self.data)
+    #     except IOError as e:
+    #         self.handle_exception(
+    #             e, 'Exception raised trying to write fits file ')
 
     def getdata(self):
         return self.data

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -91,7 +91,7 @@ class TestSkyCalcParamsGetSkySpectrum:
         assert "lam" in tbl.colnames
         assert "flux" in tbl.colnames
         assert "trans" in tbl.colnames
-        assert len(tbl) == 18
+        assert len(tbl) == 4606
 
     def test_throws_exception_for_invalid_parameters(self):
         skp["airmass"] = 9001
@@ -203,7 +203,7 @@ class TestDocExamples:
         skycalc.get_almanac_data(ra=83.8221, dec=-5.3911,
                                  date="2017-12-24T04:00:00", update_values=True)
         tbl = skycalc.get_sky_spectrum()
-        assert len(tbl) == 1701
+        assert len(tbl) == 4606
 
 #
 # class TestFunctionFixObservatory:

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -1,6 +1,5 @@
 import os
 import inspect
-from copy import deepcopy
 from datetime import datetime as dt
 
 import yaml
@@ -8,7 +7,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.io import fits
-from yaml import Loader
 
 from .core import AlmanacQuery, SkyModel
 
@@ -38,6 +36,8 @@ class SkyCalc:
         self.check_type = {pp : params[pp][2] for pp in params}
         self.allowed    = {pp : params[pp][3] for pp in params}
         self.comments   = {pp : params[pp][4] for pp in params}
+
+        self.last_skycalc_response = None
 
     def print_comments(self, param_names=None):
 
@@ -110,13 +110,34 @@ class SkyCalc:
 
         return result
 
-
     def get_sky_spectrum(self, return_type="table", filename=None):
+        """
+        Retrieve a fits.HDUList object from the SkyCalc server
+
+        The HDUList can be returned in a variety of formats.
+
+        As of v0.1.3 the HDUList is no longer saved to disk.
+        Rather it is stored in the attribute <SkyCalc>.last_skycalc_response.
+
+        Parameters
+        ----------
+        return_type : str
+            ["table", "array", "synphot", "fits"]
+        filename : str, optional
+            Default None. If not None, the returned fits.HDUList object is
+            saved to disk under this path.
+
+        Returns
+        -------
+        Based on the return type, the method returns either:
+        - "table": tbl_return (astropy.Table)
+        - "array": wave, trans, flux (3x np.ndarray)
+        - "synphot": trans, flux (SpectralElement, SourceSpectrum,)
+        - "fits": hdu (HDUList)
+
+        """
 
         from astropy import table
-
-        if filename is None:
-            filename = "skycalc_temp.fits"
 
         if not self.validate_params():
             raise ValueError("Object contains invalid parameters. "
@@ -124,15 +145,15 @@ class SkyCalc:
 
         skm = SkyModel()
         skm.callwith(self.values)
-        skm.write(filename)
+        self.last_skycalc_response = skm.data
+        if filename is not None:
+            skm.write(filename)
 
-        with fits.open(filename) as hdu:
-
-            tbl = table.Table(hdu[1].data)
-            tbl["lam"].unit = u.um
-            for colname in tbl.colnames:
-                if "flux" in colname:
-                    tbl[colname].unit = u.Unit("ph s-1 m-2 um-1 arcsec-2")
+        tbl = table.Table(skm.data[1].data)
+        tbl["lam"].unit = u.um
+        for colname in tbl.colnames:
+            if "flux" in colname:
+                tbl[colname].unit = u.Unit("ph s-1 m-2 um-1 arcsec-2")
 
         date_created = dt.now().strftime('%Y-%m-%dT%H:%M:%S')
         meta_data = {"DESCRIPT": "Sky transmission and emission curves",
@@ -191,7 +212,6 @@ class SkyCalc:
             hdu = fits.HDUList([hdu0, hdu1])
 
             return hdu
-
 
     def update(self, kwargs):
         self.values.update(kwargs)

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -96,7 +96,6 @@ class SkyCalc:
 
         return valid
 
-
     def get_almanac_data(self, ra, dec, date=None, mjd=None,
                          observatory=None, update_values=False):
 
@@ -230,7 +229,6 @@ class SkyCalc:
 
 
 def load_yaml(ipt_str):
-
     if ".yaml" in ipt_str.lower():
         if not os.path.exists(ipt_str):
             raise ValueError(ipt_str + " not found")


### PR DESCRIPTION
# 2 Minor improvements

1. Updated default parameters to use R=1000 logarithmic wavelength bins over the full SkyCalc range (0.3, 30)um
2. Removed the need to save a temp FITS file to disk by altering the skycalc_cli core code. Core code now uses `astropy.fits.open(url)` to get the FITS file from the skycalc server.