### PR TITLE
make version accessible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 # Learn more: https://github.com/kennethreitz/setup.py
 """
 Skycalc_ipy - a python wrapper for the ESO skycalc server
@@ -34,18 +35,21 @@ with open('README.md') as f:
 with open('LICENCE') as f:
     __license__ = f.read()
 
-
-setup(
-    name='skycalc-ipy',
-    version=__version__,
-    description='Get atmospheric spectral information from the ESO skycalc server',
-    long_description_content_type="text/markdown",
-    long_description=__readme__,
-    author='Kieran Leschinski',
-    author_email='kieran.leschinski@univie.ac.at',
-    url='https://github.com/AstarVienna/skycalc_ipy',
-    license=__license__,
-    include_package_data=True,
-    packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=['requests', 'pyyaml', 'numpy', 'astropy']
+def setup_package():
+    setup(
+        name='skycalc_ipy',
+        version=__version__,
+        description='Get atmospheric spectral information from the ESO skycalc server',
+        long_description_content_type="text/markdown",
+        long_description=__readme__,
+        author='Kieran Leschinski',
+        author_email='kieran.leschinski@univie.ac.at',
+        url='https://github.com/AstarVienna/skycalc_ipy',
+        license=__license__,
+        include_package_data=True,
+        packages=find_packages(exclude=('tests', 'docs')),
+        install_requires=['requests', 'pyyaml', 'numpy', 'astropy']
     )
+
+if __name__ == '__main__':
+    setup_package()

--- a/skycalc_ipy/__init__.py
+++ b/skycalc_ipy/__init__.py
@@ -6,3 +6,12 @@ from . import ui
 from . import core
 
 from .ui import SkyCalc
+
+################################################################################
+#                          VERSION INFORMATION                                 #
+################################################################################
+
+try:
+    from .version import version as __version__
+except ImportError:
+    __version__ = "Version number is not available"


### PR DESCRIPTION
`setup.py` and `__init__.py` aligned with the format of Scopesim. The goal was to make the version number accessible, as required by `scopesim.bug_report()`.