### PR TITLE
Increase REQUEST_TIMEOUT to 2 because 1 is too short for the CI

### DIFF
--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -35,7 +35,7 @@ class AlmanacQuery:
 
     """
 
-    REQUEST_TIMEOUT = 1  # Time limit (in seconds) for server response
+    REQUEST_TIMEOUT = 2  # Time limit (in seconds) for server response
 
     def __init__(self, indic):
 
@@ -192,7 +192,7 @@ class SkyModel:
 
     """
 
-    REQUEST_TIMEOUT = 1  # Time limit (in seconds) for server response
+    REQUEST_TIMEOUT = 2  # Time limit (in seconds) for server response
 
     def __init__(self):
 


### PR DESCRIPTION
Let's see whether 2 seconds does make the pipeline succeed directly