### PR TITLE
Use httpx for server connection, some restructuring and cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skycalc_ipy"
-version = "0.2.0"
+version = "0.3.0a0"
 # When updating the version, also
 # - update the date in anisocado/version.py
 # - update the release notese in docs/source/index.rst
@@ -28,7 +28,7 @@ dependencies = [
     # package on PyPI, for minimumdependencies.yml
     "numpy>=1.18.0",
     "astropy>=4.0",
-    "requests>=2.20",
+    "httpx>=0.23",
     "pyyaml>=5.3"
 ]
 

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -40,6 +40,10 @@ def get_cache_dir() -> Path:
             dir_cache = Path(getattr(sim_data, "dir_cache_skycalc"))
         except (ImportError, AttributeError):
             dir_cache = Path.home() / CACHE_DIR_FALLBACK
+
+    if not dir_cache.is_dir():
+        dir_cache.mkdir(parents=True)
+
     return dir_cache
 
 
@@ -194,7 +198,9 @@ class AlmanacQuery:
             Dictionary with the relevant parameters for the date given
 
         """
-        cache_path = get_cache_filenames(self.almindic, "almanacquery", "json")
+        cache_dir = get_cache_dir()
+        cache_name = get_cache_filenames(self.almindic, "almanacquery", "json")
+        cache_path = cache_dir / cache_name
         jsondata = self._get_jsondata(cache_path)
 
         # Find the relevant (key, value)
@@ -414,7 +420,10 @@ class SkyModel:
         }:
             self.fix_observatory()
 
-        cache_path = get_cache_filenames(self.params, "skymodel", "fits")
+        cache_dir = get_cache_dir()
+        cache_name = get_cache_filenames(self.params, "skymodel", "fits")
+        cache_path = cache_dir / cache_name
+
         if cache_path.exists():
             self.data = fits.open(cache_path)
             return

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -432,8 +432,10 @@ class SkyModel(ESOQueryBase):
 
     def _delete_server_tmpdir(self, tmpdir):
         try:
-            response = httpx.get(self.deleter_script_url, params={"d": tmpdir},
-                                 timeout=self.REQUEST_TIMEOUT)
+            with httpx.Client(base_url=self.BASE_URL,
+                              timeout=self.REQUEST_TIMEOUT) as client:
+                response = client.get(self.deleter_script_url,
+                                      params={"d": tmpdir})
             deleter_response = response.text.strip().lower()
             if deleter_response != "ok":
                 logging.error("Could not delete server tmpdir %s: %s",
@@ -480,7 +482,8 @@ class SkyModel(ESOQueryBase):
         if status == "success":
             try:
                 # retrive and save FITS data (in memory)
-                self._retrieve_data(self.data_url + tmpdir + "/skytable.fits")
+                self._retrieve_data(
+                    self.base_url + self.data_url + tmpdir + "/skytable.fits")
             except httpx.HTTPError as err:
                 logging.exception("Could not retrieve FITS data from server.")
                 raise err

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -178,12 +178,11 @@ class AlmanacQuery(ESOQueryBase):
         try:
             self.params[f"coord_{which}"] = float(indic[which])
         except KeyError as err:
-            logging.error("%s coordinate not given for the Almanac.", which)
-            logging.exception(err)
+            logging.exception("%s coordinate not given for the Almanac.",
+                              which)
             raise err
         except ValueError as err:
-            logging.error("Wrong %s format for the Almanac.", which)
-            logging.exception(err)
+            logging.exception("Wrong %s format for the Almanac.", which)
             raise err
 
     def _get_jsondata(self, file_path: Path):
@@ -405,18 +404,16 @@ class SkyModel(ESOQueryBase):
             # Use a fixed date so the stored files are always identical for
             # identical requests.
             self.data[0].header["DATE"] = "2017-01-07T00:00:00"
-        except httpx.HTTPError as err:
-            logging.error("Exception raised trying to get FITS data from %s",
-                          url)
-            logging.exception(err)
+        except httpx.HTTPError:
+            logging.exception(
+                "Exception raised trying to get FITS data from %s", url)
 
     def write(self, local_filename, **kwargs):
         """Write data to file."""
         try:
             self.data.writeto(local_filename, **kwargs)
-        except (IOError, FileNotFoundError) as err:
-            logging.error("Exception raised trying to write fits file.")
-            logging.exception(err)
+        except (IOError, FileNotFoundError):
+            logging.exception("Exception raised trying to write fits file.")
 
     def getdata(self):
         """Deprecated feature, just use the .data attribute."""
@@ -433,10 +430,9 @@ class SkyModel(ESOQueryBase):
             if deleter_response != "ok":
                 logging.error("Could not delete server tmpdir %s: %s",
                               tmpdir, deleter_response)
-        except httpx.HTTPError as err:
-            logging.error("Exception raised trying to delete tmp dir %s",
-                          tmpdir)
-            logging.exception(err)
+        except httpx.HTTPError:
+            logging.exception("Exception raised trying to delete tmp dir %s",
+                              tmpdir)
 
     def _update_params(self, updated: Mapping) -> None:
         par_keys = self.params.keys()
@@ -467,8 +463,8 @@ class SkyModel(ESOQueryBase):
             status = res["status"]
             tmpdir = res["tmpdir"]
         except (KeyError, ValueError) as err:
-            logging.error("Exception raised trying to decode server response.")
-            logging.exception(err)
+            logging.exception(
+                "Exception raised trying to decode server response.")
             raise err
 
         self._last_status = status
@@ -478,8 +474,7 @@ class SkyModel(ESOQueryBase):
                 # retrive and save FITS data (in memory)
                 self._retrieve_data(self.data_url + tmpdir + "/skytable.fits")
             except httpx.HTTPError as err:
-                logging.error("Could not retrieve FITS data from server.")
-                logging.exception(err)
+                logging.exception("Could not retrieve FITS data from server.")
                 raise err
 
             try:

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -108,6 +108,9 @@ class AlmanacQuery(ESOQueryBase):
     """
 
     def __init__(self, indic):
+        # FIXME: This basically checks isinstance(indic, ui.SkyCalc), but we
+        #        can't import that because it would create a circual import.
+        # TODO: Find a better way to do this!!
         if hasattr(indic, "defaults"):
             indic = indic.values
 
@@ -207,7 +210,7 @@ class AlmanacQuery(ESOQueryBase):
 
         return jsondata
 
-    def query(self):
+    def __call__(self):
         """
         Query the ESO Skycalc server with the parameters in self.params.
 
@@ -239,6 +242,13 @@ class AlmanacQuery(ESOQueryBase):
                                 subsection, value)
 
         return almdata
+
+    def query(self):
+        """Deprecated feature. Class is now callable, use that instead."""
+        warnings.warn("The .query() method is deprecated and will be removed "
+                      "in a future release. Please simply call the instance.",
+                      DeprecationWarning, stacklevel=2)
+        return self()
 
 
 class SkyModel(ESOQueryBase):

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -37,7 +37,6 @@ def get_cache_filenames(params: Dict, prefix: str, suffix: str):
     2. As set in the `scopesim_data` package.
     3. The `data` directory in this package.
     """
-
     if "SKYCALC_IPY_CACHE_DIR" in environ:
         dir_cache = Path(environ["SKYCALC_IPY_CACHE_DIR"])
     elif isinstance(scopesim_data, ModuleType):
@@ -55,7 +54,7 @@ def get_cache_filenames(params: Dict, prefix: str, suffix: str):
 
 class AlmanacQuery:
     """
-    A class for querying the SkyCalc Almanac
+    A class for querying the SkyCalc Almanac.
 
     Parameters
     ----------
@@ -156,7 +155,7 @@ class AlmanacQuery:
 
     def query(self):
         """
-        Queries the ESO Skycalc server with the parameters in self.almindic
+        Query the ESO Skycalc server with the parameters in self.almindic.
 
         Returns
         -------
@@ -164,7 +163,8 @@ class AlmanacQuery:
             Dictionary with the relevant parameters for the date given
 
         """
-        fn_data, fn_params = get_cache_filenames(self.almindic, "almanacquery", "json")
+        fn_data, fn_params = get_cache_filenames(self.almindic,
+                                                 "almanacquery", "json")
         if fn_data.exists():
             jsondata = json.load(open(fn_data))
         else:
@@ -209,7 +209,7 @@ class AlmanacQuery:
 
 class SkyModel:
     """
-    Class for querying the Advanced SkyModel at ESO
+    Class for querying the Advanced SkyModel at ESO.
 
     Contains all the parameters needed for querying the ESO SkyCalc server.
     The parameters are contained in :attr:`.params` and the returned FITS file
@@ -320,13 +320,12 @@ class SkyModel:
 
     def fix_observatory(self):
         """
-        Converts the human readable observatory name into its ESO ID number
+        Convert the human readable observatory name into its ESO ID number.
 
         The following observatory names are accepted: ``lasilla``, ``paranal``,
         ``armazones`` or ``3060m``, ``highanddry`` or ``5000m``
 
         """
-
         if self.params["observatory"] == "lasilla":
             self.params["observatory"] = "2400"
         elif self.params["observatory"] == "paranal":
@@ -354,7 +353,7 @@ class SkyModel:
         if key == "observatory":
             self.fix_observatory()
 
-    def handle_exception(self, err, msg):
+    def _handle_exception(self, err, msg):
         print(msg)
         print(err)
         print(self.bugreport_text)
@@ -364,15 +363,15 @@ class SkyModel:
             # tool or something like that. However, skycalc_ipy is also used as
             # a library, and libraries should never just exit and this
             # command-line functionality does not seem to exist. So instead,
-            # just raise here. See also handle_error() below.
+            # just raise here. See also _handle_error() below.
             raise
 
     # handle the kind of errors we issue ourselves.
-    def handle_error(self, msg):
+    def _handle_error(self, msg):
         print(msg)
         print(self.bugreport_text)
         if self.stop_on_errors_and_exceptions:
-            # See handle_exception above.
+            # See _handle_exception above.
             raise
 
     def retrieve_data(self, url):
@@ -382,7 +381,7 @@ class SkyModel:
             # identical requests.
             self.data[0].header["DATE"] = "2017-01-07T00:00:00"
         except requests.exceptions.RequestException as err:
-            self.handle_exception(
+            self._handle_exception(
                 err, "Exception raised trying to get FITS data from " + url
             )
 
@@ -390,7 +389,7 @@ class SkyModel:
         try:
             self.data.writeto(local_filename, **kwargs)
         except (IOError, FileNotFoundError) as err:
-            self.handle_exception(err, "Exception raised trying to write fits file ")
+            self._handle_exception(err, "Exception raised trying to write fits file ")
 
     def getdata(self):
         return self.data
@@ -402,9 +401,9 @@ class SkyModel:
             )
             deleter_response = response.text.strip()
             if deleter_response != "ok":
-                self.handle_error("Could not delete server tmpdir " + tmpdir)
+                self._handle_error("Could not delete server tmpdir " + tmpdir)
         except requests.exceptions.RequestException as err:
-            self.handle_exception(
+            self._handle_exception(
                 err, "Exception raised trying to delete tmp dir " + tmpdir
             )
 
@@ -428,7 +427,7 @@ class SkyModel:
                 self.url, data=json.dumps(self.params), timeout=self.REQUEST_TIMEOUT
             )
         except requests.exceptions.RequestException as err:
-            self.handle_exception(
+            self._handle_exception(
                 err, "Exception raised trying to POST request " + self.url
             )
             return
@@ -438,7 +437,7 @@ class SkyModel:
             status = res["status"]
             tmpdir = res["tmpdir"]
         except (KeyError, ValueError) as err:
-            self.handle_exception(
+            self._handle_exception(
                 err, "Exception raised trying to decode server response "
             )
             return
@@ -450,7 +449,7 @@ class SkyModel:
                 # retrive and save FITS data (in memory)
                 self.retrieve_data(tmpurl)
             except requests.exceptions.RequestException as err:
-                self.handle_exception(err, "could not retrieve FITS data from server")
+                self._handle_exception(err, "could not retrieve FITS data from server")
 
             try:
                 self.data.writeto(fn_data)
@@ -462,7 +461,7 @@ class SkyModel:
             self.delete_server_tmpdir(tmpdir)
 
         else:  # print why validation failed
-            self.handle_error("parameter validation error: " + res["error"])
+            self._handle_error("parameter validation error: " + res["error"])
 
         if test:
             # print 'call() returning status:',status
@@ -478,7 +477,7 @@ class SkyModel:
 
     def printparams(self, keys=None):
         """
-        List the values of all, or a subset, of parameters
+        List the values of all, or a subset, of parameters.
 
         Parameters
         ----------

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Based on the skycalc_cli package.
+Based on the skycalc_cli package, but heavily modified.
 
-This modele was taken (mostly unmodified) from ``skycalc_cli`` version 1.1.
+The original code was taken from ``skycalc_cli`` version 1.1.
 Credit for ``skycalc_cli`` goes to ESO
 """
 
@@ -76,14 +76,14 @@ class ESOQueryBase:
 
     def get_cache_filenames(self, prefix: str, suffix: str) -> str:
         """Produce filename from hass of parameters.
+
         Using three underscores between the key-value pairs and two underscores
         between the key and the value.
         """
         akey = "___".join(f"{k}__{v}" for k, v in self.params.items())
         ahash = hashlib.sha256(akey.encode("utf-8")).hexdigest()
         fname = f"{prefix}_{ahash}.{suffix}"
-        # fn_params = fn_data.with_suffix(".params.json")
-        return fname#, fn_params
+        return fname
 
 
 class AlmanacQuery(ESOQueryBase):
@@ -497,7 +497,6 @@ class SkyModel(ESOQueryBase):
 
         else:  # print why validation failed
             logging.error("Parameter validation error: %s", res["error"])
-
 
     def call(self):
         """Deprecated feature, just call the instance."""

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -409,8 +409,16 @@ class SkyModel:
                           tmpdir)
             logging.exception(err)
 
-    def call(self):
-        """Deprecated feature."""
+    def __call__(self, **kwargs):
+        """Send server request."""
+        if kwargs:
+            logging.info("Setting new parameters: %s", kwargs)
+        for key, val in kwargs.items():
+            if key in self.params:  # valid
+                self.params[key] = val
+            else:
+                logging.debug("Ignoring invalid keyword: %s", key)
+        
         if self.params["observatory"] in {
             "paranal",
             "lasilla",
@@ -464,14 +472,14 @@ class SkyModel:
             logging.error("Parameter validation error: %s", res["error"])
 
         
+
+    def call(self):
+        """Deprecated feature."""
+        self()
+
     def callwith(self, newparams):
         """Deprecated feature."""
-        for key, val in newparams.items():
-            if key in self.params:  # valid
-                self.params[key] = val
-            else:
-                logging.debug("Ignoring invalid keyword: %s", key)
-        self.call()
+        self(**newparams)
 
     def printparams(self, keys=None):
         """

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -189,8 +189,6 @@ class AlmanacQuery(ESOQueryBase):
         if file_path.exists():
             return json.load(file_path.open(encoding="utf-8"))
 
-        url = self.BASE_URL + self.url
-
         response = self._send_request()
         if not response.text:
             raise ValueError("Empty response.")
@@ -349,7 +347,7 @@ class SkyModel(ESOQueryBase):
             "lsf_boxcar_fwhm": 5.0,  # wavelength bins float > 0
             "observatory": "paranal",  # paranal
         }
-    
+
         super().__init__("/api/skycalc", params)
 
     def fix_observatory(self):

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -267,7 +267,7 @@ class SkyModel(ESOQueryBase):
 
     def __init__(self):
         self.data = None
-        self.data_url = "/tmp"
+        self.data_url = "/tmp/"
         self.deleter_script_url = "/api/rmtmp"
         self._last_status = ""
         self.tmpdir = ""
@@ -412,9 +412,10 @@ class SkyModel(ESOQueryBase):
             # Use a fixed date so the stored files are always identical for
             # identical requests.
             self.data[0].header["DATE"] = "2017-01-07T00:00:00"
-        except httpx.HTTPError:
+        except Exception as err:
             logging.exception(
                 "Exception raised trying to get FITS data from %s", url)
+            raise err
 
     def write(self, local_filename, **kwargs):
         """Write data to file."""
@@ -483,7 +484,7 @@ class SkyModel(ESOQueryBase):
             try:
                 # retrive and save FITS data (in memory)
                 self._retrieve_data(
-                    self.base_url + self.data_url + tmpdir + "/skytable.fits")
+                    self.BASE_URL + self.data_url + tmpdir + "/skytable.fits")
             except httpx.HTTPError as err:
                 logging.exception("Could not retrieve FITS data from server.")
                 raise err

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -418,9 +418,9 @@ class SkyModel:
         if cache_path.exists():
             self.data = fits.open(cache_path)
             return
-
+    
         response = _send_request(self.url, self.params, self.REQUEST_TIMEOUT)
-
+    
         try:
             res = response.json()
             status = res["status"]
@@ -429,9 +429,9 @@ class SkyModel:
             logging.error("Exception raised trying to decode server response.")
             logging.exception(err)
             raise err
-
+    
         self._last_status = status
-
+    
         if status == "success":
             try:
                 # retrive and save FITS data (in memory)
@@ -440,7 +440,7 @@ class SkyModel:
                 logging.error("Could not retrieve FITS data from server.")
                 logging.exception(err)
                 raise err
-
+    
             try:
                 self.data.writeto(cache_path)
                 # with fn_params.open("w", encoding="utf-8") as file:
@@ -448,12 +448,13 @@ class SkyModel:
             except (PermissionError, FileNotFoundError):
                 # Apparently it is not possible to save here.
                 pass
-
+    
             self._delete_server_tmpdir(tmpdir)
-
+    
         else:  # print why validation failed
             logging.error("Parameter validation error: %s", res["error"])
 
+        
     def callwith(self, newparams):
         """Deprecated feature."""
         for key, val in newparams.items():

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -111,7 +111,7 @@ class AlmanacQuery(ESOQueryBase):
         if hasattr(indic, "defaults"):
             indic = indic.values
 
-        super().__init__("/api//skycalc_almanac", indic)
+        super().__init__("/api//skycalc_almanac", {})
 
         # Left: users keyword (skycalc_cli),
         # Right: skycalc Almanac output keywords

--- a/skycalc_ipy/tests/test_core.py
+++ b/skycalc_ipy/tests/test_core.py
@@ -60,9 +60,7 @@ class TestLoadDataFromCache:
         }
 
         skymodel = core.SkyModel()
-        skymodel.callwith(params)
+        skymodel(params)
 
         alm = core.AlmanacQuery(params)
         alm.query()
-
-

--- a/skycalc_ipy/tests/test_core.py
+++ b/skycalc_ipy/tests/test_core.py
@@ -60,7 +60,7 @@ class TestLoadDataFromCache:
         }
 
         skymodel = core.SkyModel()
-        skymodel(params)
+        skymodel(**params)
 
         alm = core.AlmanacQuery(params)
         alm.query()

--- a/skycalc_ipy/tests/test_core.py
+++ b/skycalc_ipy/tests/test_core.py
@@ -1,53 +1,61 @@
+import pytest
 from pytest import raises
 from skycalc_ipy import ui
 from skycalc_ipy import core
 
 from datetime import datetime as dt
 
-# Mocks
-skp = ui.SkyCalc()
+
+@pytest.fixture
+def skp():
+    return ui.SkyCalc()
+
+
+@pytest.fixture
+def skp_basic(skp):
+    skp.update({"ra": 0, "dec": 0})
+    return skp
 
 
 class TestAlmanacInit:
-    def test_throws_exception_when_passed_virgin_SkyCalcParams(self):
+    def test_throws_exception_when_passed_virgin_SkyCalcParams(self, skp):
         with raises(ValueError):
             core.AlmanacQuery(skp)
 
-    def test_passes_for_valid_SkyCalcParams_with_date(self):
+    def test_passes_for_valid_SkyCalcParams_with_date(self, skp):
         skp.update({"ra": 0, "dec": 0, "date": "2000-1-1T0:0:0", "mjd": None})
         alm = core.AlmanacQuery(skp)
-        print(alm.almindic)
         assert alm.almindic["coord_year"] == 2000
         assert alm.almindic["coord_ut_sec"] == 0
         assert alm.almindic["input_type"] == "ut_time"
 
-    def test_passes_for_valid_SkyCalcParams_with_mjd(self):
-        skp.update({"mjd": 0, "date": None})
-        alm = core.AlmanacQuery(skp)
-        print(alm.almindic)
+    def test_passes_for_valid_SkyCalcParams_with_mjd(self, skp_basic):
+        skp_basic.update({"mjd": 0, "date": None})
+        alm = core.AlmanacQuery(skp_basic)
         assert alm.almindic["mjd"] == 0
         assert alm.almindic["input_type"] == "mjd"
 
-    def test_throws_exception_when_date_and_mjd_are_empty(self):
-        skp.update({"mjd": None, "date": None})
+    def test_throws_exception_when_date_and_mjd_are_empty(self, skp_basic):
+        skp_basic.update({"mjd": None, "date": None})
         with raises(ValueError):
-            core.AlmanacQuery(skp)
+            core.AlmanacQuery(skp_basic)
 
-    def test_passes_for_date_as_datetime_object(self):
-        skp.update({"date": dt(1986, 4, 26, 1, 24)})
-        alm = core.AlmanacQuery(skp)
+    def test_passes_for_date_as_datetime_object(self, skp_basic):
+        skp_basic.update({"date": dt(1986, 4, 26, 1, 24)})
+        alm = core.AlmanacQuery(skp_basic)
         assert alm.almindic["coord_ut_min"] == 24
         assert alm.almindic["input_type"] == "ut_time"
 
-    def test_throws_exception_when_date_is_unintelligible(self):
-        skp.update({"date": "bogus"})
+    def test_throws_exception_when_date_is_unintelligible(self, skp_basic):
+        skp_basic.update({"date": "bogus"})
         with raises(ValueError):
-            core.AlmanacQuery(skp)
+            core.AlmanacQuery(skp_basic)
 
-    def test_throws_exception_when_mjd_is_unintelligible(self):
-        skp.update({"mjd": "bogus"})
+    def test_throws_exception_when_mjd_is_unintelligible(self, skp_basic):
+        skp_basic.update({"mjd": "bogus"})
         with raises(ValueError):
-            core.AlmanacQuery(skp)
+            core.AlmanacQuery(skp_basic)
+
 
 class TestLoadDataFromCache:
     def test_load_skymodel_from_cache(self):

--- a/skycalc_ipy/tests/test_core.py
+++ b/skycalc_ipy/tests/test_core.py
@@ -71,4 +71,4 @@ class TestLoadDataFromCache:
         skymodel(**params)
 
         alm = core.AlmanacQuery(params)
-        alm.query()
+        _ = alm()

--- a/skycalc_ipy/tests/test_core.py
+++ b/skycalc_ipy/tests/test_core.py
@@ -25,15 +25,15 @@ class TestAlmanacInit:
     def test_passes_for_valid_SkyCalcParams_with_date(self, skp):
         skp.update({"ra": 0, "dec": 0, "date": "2000-1-1T0:0:0", "mjd": None})
         alm = core.AlmanacQuery(skp)
-        assert alm.almindic["coord_year"] == 2000
-        assert alm.almindic["coord_ut_sec"] == 0
-        assert alm.almindic["input_type"] == "ut_time"
+        assert alm.params["coord_year"] == 2000
+        assert alm.params["coord_ut_sec"] == 0
+        assert alm.params["input_type"] == "ut_time"
 
     def test_passes_for_valid_SkyCalcParams_with_mjd(self, skp_basic):
         skp_basic.update({"mjd": 0, "date": None})
         alm = core.AlmanacQuery(skp_basic)
-        assert alm.almindic["mjd"] == 0
-        assert alm.almindic["input_type"] == "mjd"
+        assert alm.params["mjd"] == 0
+        assert alm.params["input_type"] == "mjd"
 
     def test_throws_exception_when_date_and_mjd_are_empty(self, skp_basic):
         skp_basic.update({"mjd": None, "date": None})
@@ -43,8 +43,8 @@ class TestAlmanacInit:
     def test_passes_for_date_as_datetime_object(self, skp_basic):
         skp_basic.update({"date": dt(1986, 4, 26, 1, 24)})
         alm = core.AlmanacQuery(skp_basic)
-        assert alm.almindic["coord_ut_min"] == 24
-        assert alm.almindic["input_type"] == "ut_time"
+        assert alm.params["coord_ut_min"] == 24
+        assert alm.params["input_type"] == "ut_time"
 
     def test_throws_exception_when_date_is_unintelligible(self, skp_basic):
         skp_basic.update({"date": "bogus"})

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -61,19 +61,17 @@ class TestSkycalcParamsInit:
         assert output == "airmass : airmass in range [1.0, 3.0]"
 
     def test_print_comments_mutliple_keywords(self, skp, capsys):
-        skp.print_comments(["airmass", "season"])
+        skp.print_comments("airmass", "season")
         output = capsys.readouterr()[0].strip()
-        assert (
-            output
-            == "airmass : airmass in range [1.0, 3.0]\n"
-            + "season : 0=all year, 1=dec/jan,2=feb/mar..."
-        )
+        expected = ("airmass : airmass in range [1.0, 3.0]\n"
+                    " season : 0=all year, 1=dec/jan,2=feb/mar...")
+        assert output == expected
 
     def test_print_comments_misspelled_keyword(self, skp, capsys):
-        skp.print_comments(["iarmass"])
+        skp.print_comments("iarmass")
         sys_out = capsys.readouterr()
         output = sys_out[0].strip()
-        assert output == "iarmass not found"
+        assert output == "iarmass : <parameter not found>"
 
     def test_keys_returns_list_of_keys(self, skp):
         assert isinstance(skp.keys, Sequence)

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -9,6 +9,9 @@ from astropy.io import fits
 import synphot as sp
 
 
+PATH_HERE = Path(__file__).parent
+
+
 @pytest.fixture
 def skp():
     return ui.SkyCalc()
@@ -34,7 +37,7 @@ def basic_almanac_no_update(skp):
 
 class TestLoadYaml:
     def test_finds_file_for_specified_path(self):
-        yaml_dict = ui.load_yaml(Path(__file__).parent.parent / "params.yaml")
+        yaml_dict = ui.load_yaml(PATH_HERE.parent / "params.yaml")
         assert yaml_dict["season"][0] == 0
 
     def test_throws_exception_for_nonexistent_file(self):

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from collections.abc import Sequence, Mapping
 
 import pytest
 from pytest import raises
@@ -52,7 +53,7 @@ class TestLoadYaml:
 
 class TestSkycalcParamsInit:
     def test_loads_default_when_no_file_given(self, skp):
-        assert type(skp.defaults) == dict
+        assert isinstance(skp.defaults, Mapping)
         assert skp.defaults["observatory"] == "paranal"
         assert skp.allowed["therm_t2"] == 0
 
@@ -77,29 +78,29 @@ class TestSkycalcParamsInit:
         assert output == "iarmass not found"
 
     def test_keys_returns_list_of_keys(self, skp):
-        assert type(skp.keys) == list
+        assert isinstance(skp.keys, Sequence)
         assert "observatory" in skp.keys
 
 
 class TestSkycalcParamsValidateMethod:
     def test_returns_true_for_all_good(self, skp):
-        assert skp.validate_params() is True
+        assert skp.validate_params()
 
     def test_returns_false_for_bung_YN_flag(self, skp):
         skp["incl_starlight"] = "Bogus"
-        assert skp.validate_params() is False
+        assert not skp.validate_params()
 
     def test_returns_false_for_bung_string_in_array(self, skp):
         skp["lsf_type"] = "Bogus"
-        assert skp.validate_params() is False
+        assert not skp.validate_params()
 
     def test_returns_false_for_value_outside_range(self, skp):
         skp["airmass"] = 0.5
-        assert skp.validate_params() is False
+        assert not skp.validate_params()
 
     def test_returns_false_for_value_below_zero(self, skp):
         skp["lsf_boxcar_fwhm"] = -5.0
-        assert skp.validate_params() is False
+        assert not skp.validate_params()
 
 
 class TestSkyCalcParamsGetSkySpectrum:
@@ -195,7 +196,7 @@ class TestFunctionGetAlmanacData:
         out_dict = ui.get_almanac_data(
             ra=180, dec=0, date="2000-1-1T0:0:0", observatory="lasilla"
         )
-        assert type(out_dict) == dict
+        assert isinstance(out_dict, Mapping)
         assert len(out_dict) == 9
         assert out_dict["observatory"] == "lasilla"
 
@@ -204,7 +205,7 @@ class TestFunctionGetAlmanacData:
         out_dict = ui.get_almanac_data(
             ra=180, dec=0, date="2000-1-1T0:0:0", return_full_dict=True
         )
-        assert type(out_dict) == dict
+        assert isinstance(out_dict, Mapping)
         assert len(out_dict) == 39
         assert type(out_dict["moon_sun_sep"]) == float
 
@@ -213,7 +214,7 @@ class TestFunctionGetAlmanacData:
         out_dict = ui.get_almanac_data(
             ra=180, dec=0, date="2000-1-1T0:0:0", return_full_dict=False
         )
-        assert type(out_dict) == dict
+        assert isinstance(out_dict, Mapping)
         assert len(out_dict) == 9
 
     @pytest.mark.webtest

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -217,13 +217,13 @@ class TestFunctionGetAlmanacData:
         assert len(out_dict) == 9
 
     @pytest.mark.webtest
-    def test_take_date_only_if_date_and_mjd_are_valid(self, capsys):
+    def test_take_date_only_if_date_and_mjd_are_valid(self):
         out_dict_date = ui.get_almanac_data(ra=180, dec=0, date="2000-1-1T0:0:0")
-        out_dict_both = ui.get_almanac_data(
-            ra=180, dec=0, mjd=50000, date="2000-1-1T0:0:0"
-        )
-        output = capsys.readouterr()[0].strip()
-        assert output == "Warning: Both date and mjd are set. Using date"
+        with pytest.warns(UserWarning) as record:
+            out_dict_both = ui.get_almanac_data(
+                ra=180, dec=0, mjd=50000, date="2000-1-1T0:0:0"
+            )
+        assert record[0].message.args[0] == "Both date and mjd are set. Using date"
         assert out_dict_both == out_dict_date
 
 

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -218,7 +218,8 @@ class TestFunctionGetAlmanacData:
 
     @pytest.mark.webtest
     def test_take_date_only_if_date_and_mjd_are_valid(self):
-        out_dict_date = ui.get_almanac_data(ra=180, dec=0, date="2000-1-1T0:0:0")
+        out_dict_date = ui.get_almanac_data(
+            ra=180, dec=0, date="2000-1-1T0:0:0")
         with pytest.warns(UserWarning) as record:
             out_dict_both = ui.get_almanac_data(
                 ra=180, dec=0, mjd=50000, date="2000-1-1T0:0:0"

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -1,5 +1,4 @@
-import os
-import inspect
+from pathlib import Path
 
 import pytest
 from pytest import raises
@@ -17,13 +16,12 @@ skp_small["wdelta"] = 100
 
 class TestLoadYaml:
     def test_finds_file_for_specified_path(self):
-        dirname = os.path.dirname(inspect.getfile(inspect.currentframe()))
-        yaml_dict = ui.load_yaml(os.path.join(dirname, "../params.yaml"))
+        yaml_dict = ui.load_yaml(Path(__file__).parent.parent / "params.yaml")
         assert yaml_dict["season"][0] == 0
 
     def test_throws_exception_for_nonexistent_file(self):
         with raises(ValueError):
-            ui.load_yaml("bogus.yaml")
+            ui.load_yaml(Path("bogus.yaml"))
 
     def test_accepts_string_block_input(self):
         str_yaml = """

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -18,11 +18,6 @@ def skp():
 
 
 @pytest.fixture
-def skp2():
-    return ui.SkyCalc()
-
-
-@pytest.fixture
 def skp_small():
     skps = ui.SkyCalc()
     skps["wdelta"] = 100

--- a/skycalc_ipy/tests/test_ui.py
+++ b/skycalc_ipy/tests/test_ui.py
@@ -25,7 +25,7 @@ class TestLoadYaml:
 
     def test_accepts_string_block_input(self):
         str_yaml = """
-        params : 
+        params :
         - hello
         - world
         """
@@ -216,7 +216,9 @@ class TestDocExamples:
     def test_example(self):
         skycalc = ui.SkyCalc()
         skycalc.get_almanac_data(
-            ra=83.8221, dec=-5.3911, date="2017-12-24T04:00:00", update_values=True
+            ra=83.8221, dec=-5.3911,
+            date="2017-12-24T04:00:00",
+            update_values=True
         )
         tbl = skycalc.get_sky_spectrum()
         assert len(tbl) == 4606

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -2,6 +2,7 @@
 """Skyclc IPY user interface."""
 
 import logging
+import warnings
 from pathlib import Path
 from datetime import datetime as dt
 
@@ -266,7 +267,8 @@ def get_almanac_data(
     observatory=None,
 ):
     if date is not None and mjd is not None:
-        logging.warning("Both date and mjd are set. Using date")
+        warnings.warn("Both date and mjd are set. Using date",
+                      UserWarning, stacklevel=2)
 
     skycalc_params = SkyCalc()
     skycalc_params.values.update({"ra": ra, "dec": dec, "date": date, "mjd": mjd})

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -114,7 +114,7 @@ class SkyCalc:
 
     def get_sky_spectrum(self, return_type="table", filename=None):
         """
-        Retrieve a fits.HDUList object from the SkyCalc server
+        Retrieve a fits.HDUList object from the SkyCalc server.
 
         The HDUList can be returned in a variety of formats.
 
@@ -138,7 +138,6 @@ class SkyCalc:
         - "fits": hdu (HDUList)
 
         """
-
         from astropy import table
 
         if not self.validate_params():

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -47,19 +47,14 @@ class SkyCalc:
 
         self.last_skycalc_response = None
 
-    def print_comments(self, param_names=None):
-        """Print descriptions of parameters."""
-        if param_names is None:
-            param_names = list(self.comments.keys())
-
-        if isinstance(param_names, str):
-            param_names = [param_names]
+    def print_comments(self, *param_names):
+        """Print descriptions of parameters. Print all if no names given."""
+        param_names = param_names or list(self.comments.keys())
+        maxkeylen = len(max(param_names, key=len))
 
         for pname in param_names:
-            if pname not in self.comments:
-                print(f"{pname} not found")
-            else:
-                print(f"{pname} : {self.comments[pname]}")
+            comment = self.comments.get(pname, "<parameter not found>")
+            print(f"{pname:>{maxkeylen}} : {comment}")
 
     def validate_params(self):
         """Check allowed range for parameters."""
@@ -88,11 +83,7 @@ class SkyCalc:
                 if self.values[key] < self.allowed[key]:
                     invalid_keys.append(key)
 
-            else:
-                pass
-
         if invalid_keys:
-            logging.warning("See <SkyCalc>.comments[<key>] for help")
             logging.warning("The following entries are invalid:")
             for key in invalid_keys:
                 logging.warning("'%s' : %s : %s", key,
@@ -241,7 +232,8 @@ class SkyCalc:
 
     def __setitem__(self, key, value):
         if key not in self.keys:
-            raise ValueError(key + " not in self.defaults")
+            raise KeyError(f"Key {key} is not defined. Only predefined keys "
+                           "can be set. See SkyCalc.keys for a list of those.")
         self.values[key] = value
 
     def __getitem__(self, item):

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -16,6 +16,7 @@ from .core import AlmanacQuery, SkyModel
 
 __all__ = ["SkyCalc"]
 
+# TODO: this isn't used, but something VERY similar is done in core......
 observatory_dict = {
     "lasilla": "2400",
     "paranal": "2640",
@@ -278,8 +279,7 @@ def get_almanac_data(
     if observatory is not None:
         skycalc_params.values["observatory"] = observatory
     skycalc_params.validate_params()
-    alm = AlmanacQuery(skycalc_params.values)
-    response = alm()
+    response = AlmanacQuery(skycalc_params.values)()
 
     if return_full_dict:
         skycalc_params.values.update(response)

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -144,7 +144,7 @@ class SkyCalc:
             raise ValueError("Object contains invalid parameters. Not calling ESO")
 
         skm = SkyModel()
-        skm.callwith(self.values)
+        skm(self.values)
         self.last_skycalc_response = skm.data
         if filename is not None:
             skm.write(filename)

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -25,11 +25,12 @@ observatory_dict = {
     "highanddry": "5000",
 }
 
+PATH_HERE = Path(__file__).parent
 
 class SkyCalc:
     def __init__(self, ipt_str=None):
         if ipt_str is None:
-            ipt_str = Path(__file__).parent / "params.yaml"
+            ipt_str = PATH_HERE / "params.yaml"
 
         params = load_yaml(ipt_str)
 

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -1,5 +1,8 @@
-import os
-import inspect
+# -*- coding: utf-8 -*-
+"""Skyclc IPY user interface."""
+
+import logging
+from pathlib import Path
 from datetime import datetime as dt
 
 import yaml
@@ -25,8 +28,7 @@ observatory_dict = {
 class SkyCalc:
     def __init__(self, ipt_str=None):
         if ipt_str is None:
-            dirname = os.path.dirname(inspect.getfile(inspect.currentframe()))
-            ipt_str = os.path.join(dirname, "params.yaml")
+            ipt_str = Path(__file__).parent / "params.yaml"
 
         params = load_yaml(ipt_str)
 
@@ -82,10 +84,11 @@ class SkyCalc:
                 pass
 
         if invalid_keys:
-            print("See <SkyCalc>.comments[<key>] for help")
-            print("The following entries are invalid:")
+            logging.warning("See <SkyCalc>.comments[<key>] for help")
+            logging.warning("The following entries are invalid:")
             for key in invalid_keys:
-                print(f"'{key}' : {self.values[key]} : {self.comments[key]}")
+                logging.warning("'%s' : %s : %s", key,
+                                self.values[key], self.comments[key])
 
         return not invalid_keys
 
@@ -208,8 +211,8 @@ class SkyCalc:
                 points=tbl["lam"].data * tbl["lam"].unit,
                 lookup_table=tbl["flux"].data * funit,
             )
-            print(
-                "Warning: synphot doesn't accept surface brightnesses \n"
+            logging.warning(
+                "Synphot doesn't accept surface brightnesses \n"
                 "The resulting spectrum should be multiplied by arcsec-2"
             )
 
@@ -241,11 +244,12 @@ class SkyCalc:
 
 
 def load_yaml(ipt_str):
-    if ".yaml" in ipt_str.lower():
-        if not os.path.exists(ipt_str):
-            raise ValueError(ipt_str + " not found")
+    # TODO: why not just load, what's all of this?
+    if ".yaml" in str(ipt_str).lower():
+        if not ipt_str.exists():
+            raise ValueError(f"{ipt_str} not found")
 
-        with open(ipt_str, "r") as fd:
+        with ipt_str.open("r", encoding="utf-8") as fd:
             fd = "\n".join(fd.readlines())
         opts_dict = yaml.load(fd, Loader=yaml.FullLoader)
     else:
@@ -263,7 +267,7 @@ def get_almanac_data(
     observatory=None,
 ):
     if date is not None and mjd is not None:
-        print("Warning: Both date and mjd are set. Using date")
+        logging.warning("Both date and mjd are set. Using date")
 
     skycalc_params = SkyCalc()
     skycalc_params.values.update({"ra": ra, "dec": dec, "date": date, "mjd": mjd})

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -28,7 +28,10 @@ observatory_dict = {
 
 PATH_HERE = Path(__file__).parent
 
+
 class SkyCalc:
+    """Main UI class."""
+
     def __init__(self, ipt_str=None):
         if ipt_str is None:
             ipt_str = PATH_HERE / "params.yaml"
@@ -45,6 +48,7 @@ class SkyCalc:
         self.last_skycalc_response = None
 
     def print_comments(self, param_names=None):
+        """Print descriptions of parameters."""
         if param_names is None:
             param_names = list(self.comments.keys())
 
@@ -58,6 +62,7 @@ class SkyCalc:
                 print(f"{pname} : {self.comments[pname]}")
 
     def validate_params(self):
+        """Check allowed range for parameters."""
         invalid_keys = []
         for key in self.values:
             if self.check_type[key] == "no_check" or self.defaults[key] is None:
@@ -104,6 +109,7 @@ class SkyCalc:
         observatory=None,
         update_values=False,
     ):
+        """Query ESO Almanac with given parameters."""
         if date is None and mjd is None:
             raise ValueError("Either date or mjd must be set")
 

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -144,7 +144,7 @@ class SkyCalc:
             raise ValueError("Object contains invalid parameters. Not calling ESO")
 
         skm = SkyModel()
-        skm(self.values)
+        skm(**self.values)
         self.last_skycalc_response = skm.data
         if filename is not None:
             skm.write(filename)

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -279,7 +279,7 @@ def get_almanac_data(
         skycalc_params.values["observatory"] = observatory
     skycalc_params.validate_params()
     alm = AlmanacQuery(skycalc_params.values)
-    response = alm.query()
+    response = alm()
 
     if return_full_dict:
         skycalc_params.values.update(response)

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -158,7 +158,7 @@ class SkyCalc:
                 # Somehow, astropy doesn't quite parse the unit correctly.
                 # Still, we shouldn't blindly overwrite it, so at least check.
                 funit = tbl[colname].unit
-                if not str(funit) in ("ph/s/m2/micron/arcsec2", "None"):
+                if str(funit) not in ("ph/s/m2/micron/arcsec2", "None"):
                     raise ValueError(f"Unexpected flux unit: {funit}")
                 tbl[colname].unit = u.Unit("ph s-1 m-2 um-1 arcsec-2")
 

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -142,7 +142,8 @@ class SkyCalc:
         from astropy import table
 
         if not self.validate_params():
-            raise ValueError("Object contains invalid parameters. Not calling ESO")
+            raise ValueError(
+                "Object contains invalid parameters. Not calling ESO")
 
         skm = SkyModel()
         skm(**self.values)
@@ -271,7 +272,8 @@ def get_almanac_data(
                       UserWarning, stacklevel=2)
 
     skycalc_params = SkyCalc()
-    skycalc_params.values.update({"ra": ra, "dec": dec, "date": date, "mjd": mjd})
+    skycalc_params.values.update(
+        {"ra": ra, "dec": dec, "date": date, "mjd": mjd})
     if observatory is not None:
         skycalc_params.values["observatory"] = observatory
     skycalc_params.validate_params()


### PR DESCRIPTION
Migrate the whole package from `requests` to `httpx`, which nicely fits the kind of web requests we're doing here and is easily expandable, should we ever need more advanced functionality.

Additionally, the location of the cached files is changed to something more reasonable than inside the package directory (still supports scopesim_data and an environ variable). Dropped caching of parameter JSON file, I don't think this was used anywhere at all. General working principle of the cache (hash of input parameter combination) is unchanged.

In the course of that, I also changed some other things:

- use `pathlib.Path` instead of `os.path`, also in the tests
- use logging instead of printing, except in methods that have "print" in the name
- add a base class for the two previous classes in `core` to inherit from, related to common request operations
- rename various parameters to make the two now-sibling classes more similar
- make these classes callable, because they really only have one main use, and one even had a `.call()` method before...
- some improvements of the tests, most notably use actual fixtures instead of just calling global instances "mocks"
- add more docstrings
- multiple minor changes and improvements, formatting

Several aspects of this still need some attention, but it's a big step forward. I also bumped the development version number in the pyproject.toml file, because the structure changed significantly enough that this should be a minor version increase once we release it...