### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Build Status](https://github.com/AstarVienna/skycalc_ipy/actions/workflows/tests.yml/badge.svg)](https://github.com/AstarVienna/skycalc_ipy/actions/workflows/tests.yml/badge.svg)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 ![dev version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FAstarVienna%2Fskycalc_ipy%2Fmaster%2Fpyproject.toml&query=%24.tool.poetry.version&label=dev%20version&color=teal)
-![Server Status](https://img.shields.io/website?url=https%3A%2F%2Fetimecalret-002.eso.org%2Fobserving%2Fetc%2F&label=ESO%20ETC%20server)
+![Server Status](https://img.shields.io/website?url=https%3A%2F%2Fetimecalret-002.eso.org%2Fobserving%2Fetc%2Fapi%2Fskycalc%2F&label=ESO%20ETC%20server)
 
 [![Documentation Status](https://readthedocs.org/projects/skycalc-ipy/badge/?version=latest)](https://skycalc-ipy.readthedocs.io/en/latest)
 [![codecov](https://codecov.io/gh/AstarVienna/skycalc_ipy/graph/badge.svg)](https://codecov.io/gh/AstarVienna/skycalc_ipy)
 [![PyPI - Version](https://img.shields.io/pypi/v/skycalc-ipy)](https://pypi.org/project/skycalc-ipy/)
-![Python Version Support](https://github-actions.40ants.com/AstarVienna/DevOps/matrix.svg?only=Tests.build.ubuntu-latest)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/skycalc-ipy)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Citation](https://img.shields.io/badge/ascl-2109.007-blue.svg?colorB=262255)](https://ascl.net/2109.007)


### PR DESCRIPTION
1. The server status badge was incorrectly showing the server as up, when it's been down for two weeks now. Using the full API URL instead of just the base URL to get a more realistic server status.
2. As in ScopeSim, the python version badge backend is no longer working, so switching to a PyPI-based badge, which was planned anyway.