### PR TITLE
Improve logging

### DIFF
--- a/skycalc_ipy/__init__.py
+++ b/skycalc_ipy/__init__.py
@@ -8,6 +8,10 @@ from . import core
 
 from .ui import SkyCalc
 
+import logging
+logger = logging.getLogger("astar." + __name__)
+logger.addHandler(logging.NullHandler())
+
 ################################################################################
 #                          VERSION INFORMATION                                 #
 ################################################################################

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -27,6 +27,7 @@ observatory_dict = {
 }
 
 PATH_HERE = Path(__file__).parent
+logger = logging.getLogger("astar." + __name__)
 
 
 class SkyCalc:
@@ -84,10 +85,10 @@ class SkyCalc:
                     invalid_keys.append(key)
 
         if invalid_keys:
-            logging.warning("The following entries are invalid:")
+            logger.warning("The following entries are invalid:")
             for key in invalid_keys:
-                logging.warning("'%s' : %s : %s", key,
-                                self.values[key], self.comments[key])
+                logger.warning("'%s' : %s : %s", key,
+                               self.values[key], self.comments[key])
 
         return not invalid_keys
 
@@ -211,7 +212,7 @@ class SkyCalc:
                 points=tbl["lam"].data * tbl["lam"].unit,
                 lookup_table=tbl["flux"].data * funit,
             )
-            logging.warning(
+            logger.warning(
                 "Synphot doesn't accept surface brightnesses \n"
                 "The resulting spectrum should be multiplied by arcsec-2"
             )


### PR DESCRIPTION
## Correct loggers

Until now, our logging here used the _root logger_, which is the result of simply running `logging.warning()/error()/etc` without any other configuration. This is not ideal for a number of reasons and also "strongly advised" against in [the docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library). There are now three separate [`Loggers`](https://docs.python.org/3/howto/logging.html#loggers), one for each module (`core` and `ui`) and one top level logger for the package. As per the same paragraph in said docs, I included a [`NullHandler`](https://docs.python.org/3/library/logging.handlers.html#logging.NullHandler) to the top logger.

## Interoperability

In line with the planned changes in our other packages, all logger names start with `"astar."`, so it will be easy to collect all logging from all our packages if used together in the future.