### PR TITLE
Move version info to `__init__.py`

### DIFF
--- a/skycalc_ipy/__init__.py
+++ b/skycalc_ipy/__init__.py
@@ -8,11 +8,6 @@ from . import core
 
 from .ui import SkyCalc
 
-################################################################################
-#                          VERSION INFORMATION                                 #
-################################################################################
+from importlib import metadata
 
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = "Version number is not available"
+__version__ = metadata.version(__package__)

--- a/skycalc_ipy/version.py
+++ b/skycalc_ipy/version.py
@@ -1,3 +1,0 @@
-from importlib import metadata
-
-version = metadata.version(__package__)


### PR DESCRIPTION
After removing the unneeded date from `version.py`, there was little use in keeping this in a separate module. Unless I'm missing something. Was there any case where the `"Version number is not available"` would be needed?