### PR TITLE
Standardization of CI and logging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,16 @@ on:
 
 jobs:
   call-tests:
-    name: Call tests
+    name: Offline tests
     uses: AstarVienna/DevOps/.github/workflows/tests.yml@poetry
+    secrets: inherit
+
+  call-webtests:
+    name: Network tests
+    uses: AstarVienna/DevOps/.github/workflows/webtests.yml@poetry
+    secrets: inherit
+
+  call-updated-tests:
+    name: Tests with updated dependencies
+    uses: AstarVienna/DevOps/.github/workflows/updated_tests.yml@poetry
     secrets: inherit

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,22 @@ files = [
 ]
 
 [[package]]
+name = "astar-utils"
+version = "0.2.0b1"
+description = "Contains commonly-used utilities for AstarVienna's projects."
+optional = false
+python-versions = ">=3.9,<4.0"
+files = [
+    {file = "astar_utils-0.2.0b1-py3-none-any.whl", hash = "sha256:b59aaeb5920333c528aa7bef07a04a009e9a1e668e84e3cfbc09fdd8dae7fdda"},
+    {file = "astar_utils-0.2.0b1.tar.gz", hash = "sha256:f9a5fd493623c36d79f7df97f011e073fadddfe9ea94fe35d0abee82bbbf1a2b"},
+]
+
+[package.dependencies]
+colorama = ">=0.4.6,<0.5.0"
+more-itertools = ">=10.1.0,<11.0.0"
+pyyaml = ">=6.0.1,<7.0.0"
+
+[[package]]
 name = "astropy"
 version = "5.3.3"
 description = "Astronomy and astrophysics core library"
@@ -1294,6 +1310,17 @@ files = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "more-itertools-10.2.0.tar.gz", hash = "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"},
+    {file = "more_itertools-10.2.0-py3-none-any.whl", hash = "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684"},
+]
+
+[[package]]
 name = "nbclient"
 version = "0.9.0"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
@@ -1884,7 +1911,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2653,4 +2679,4 @@ syn = ["synphot"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9bbb200f5085b5e241c6f72cd6f3f7ff32beda5ba89cd9948708b7d5f899e3ad"
+content-hash = "dd83426796de3759d32f8b8c9812f311a0410461e9b0273e07349db846cdbbe9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ httpx = "^0.23.0"
 pyyaml = "^6.0.1"
 
 synphot = { version = "^1.2.1", optional = true }
+astar-utils = {version = ">=0.2.0b0", allow-prereleases = true}
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.3"

--- a/skycalc_ipy/__init__.py
+++ b/skycalc_ipy/__init__.py
@@ -8,9 +8,11 @@ from . import core
 
 from .ui import SkyCalc
 
-import logging
-logger = logging.getLogger("astar." + __name__)
-logger.addHandler(logging.NullHandler())
+from logging import NullHandler
+from astar_utils import get_logger
+
+_logger = get_logger(__package__)
+_logger.addHandler(NullHandler())
 
 from importlib import metadata
 

--- a/skycalc_ipy/core.py
+++ b/skycalc_ipy/core.py
@@ -6,7 +6,6 @@ The original code was taken from ``skycalc_cli`` version 1.1.
 Credit for ``skycalc_cli`` goes to ESO
 """
 
-import logging
 import warnings
 
 import hashlib
@@ -21,9 +20,10 @@ import httpx
 
 from astropy.io import fits
 
+from astar_utils import get_logger
 
 CACHE_DIR_FALLBACK = ".astar/skycalc_ipy"
-logger = logging.getLogger("astar." + __name__)
+logger = get_logger(__name__)
 
 
 def get_cache_dir() -> Path:

--- a/skycalc_ipy/ui.py
+++ b/skycalc_ipy/ui.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Skyclc IPY user interface."""
 
-import logging
 import warnings
 from pathlib import Path
 from datetime import datetime as dt
@@ -11,6 +10,8 @@ import numpy as np
 
 from astropy import units as u
 from astropy.io import fits
+
+from astar_utils import get_logger
 
 from .core import AlmanacQuery, SkyModel
 
@@ -27,7 +28,7 @@ observatory_dict = {
 }
 
 PATH_HERE = Path(__file__).parent
-logger = logging.getLogger("astar." + __name__)
+logger = get_logger(__name__)
 
 
 class SkyCalc:


### PR DESCRIPTION
- Use new DevOps split tests and updated dependency tests.
- Use logger factory from astar-utils