### PR TITLE
Relax httpx dependency from ^0.23.0 to >=0.23.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1676,4 +1676,4 @@ syn = ["synphot"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "34f8e3ab47e714512495456464e13e795e84637e1db210d5e1c72cd318f519f4"
+content-hash = "88d23911d9b9a5d81781638dec5cb10862581449c6bcf0bcf8ebd947b61ef3b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 python = "^3.10"
 numpy = "^1.26.3"
 astropy = "^5.3.4"
-httpx = "^0.23.0"
+httpx = ">=0.23.0"
 pyyaml = "^6.0.1"
 
 astar-utils = ">=0.2.0"


### PR DESCRIPTION
The carret prevents any newer 'minor' releases of httpx to be used, because the 'major' version is 0. This makes it difficult to upgrade other dependencies of ScopeSim like notebook, because those depend on newer versions of httpx.

It is probably fine to just use >= for httpx, as we only use basic features that will probably not be deprecated or break.