### PR TITLE
Allow numpy 2.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1726,4 +1726,4 @@ syn = ["synphot"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b8a4cf41d2266110180540f26b490c08dfcbff2c44b52490894012ed7fd66775"
+content-hash = "e3af6b9340881cf64e84011fd58c3f7b8754d121fbb666b89fdc0312033b67cc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -51,14 +51,14 @@ trio = ["trio (<0.22)"]
 
 [[package]]
 name = "astar-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "Contains commonly-used utilities for AstarVienna's projects."
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "astar_utils-0.3.0-py3-none-any.whl", hash = "sha256:473d056c4c873fbf077fcc2249f8c3d5bfd37083d9289b13dc2fde7fb6eed872"},
-    {file = "astar_utils-0.3.0.tar.gz", hash = "sha256:c7102b4347c7e4463927e0d3066f03bc6a0d784af8252599e18277c0313a8912"},
+    {file = "astar_utils-0.3.1-py3-none-any.whl", hash = "sha256:6cb6cac868ec4642130183ad3f9519cd60cf37b7326ff0bf38a19caee90d5638"},
+    {file = "astar_utils-0.3.1.tar.gz", hash = "sha256:eae7108aa508b5c6364aac7c4e6160ea13ff5d5887550477a477eb62db4c5270"},
 ]
 
 [package.dependencies]
@@ -1726,4 +1726,4 @@ syn = ["synphot"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e3af6b9340881cf64e84011fd58c3f7b8754d121fbb666b89fdc0312033b67cc"
+content-hash = "3b3c5318321ad7780c0f02c2e9ac6dccc0d77bea4081b32655016334680282b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ astropy = "^6.0.1"
 httpx = ">=0.26.0"
 pyyaml = "^6.0.1"
 
-astar-utils = ">=0.3.0"
+astar-utils = ">=0.3.1"
 
 synphot = { version = "^1.4.0", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-numpy = "^1.26.3"
+numpy = ">=1.26.3, <3"
 astropy = "^6.0.1"
 httpx = ">=0.26.0"
 pyyaml = "^6.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skycalc-ipy"
-version = "0.5.3a0"
+version = "0.5.3b0"
 description = "Get atmospheric spectral information from the ESO skycalc server."
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]


### PR DESCRIPTION
If tests pass, why not. Shouldn't break anything else right now, projects that depend on this package but require numpy < 2 will still be able to install. Closes #79.